### PR TITLE
Legacy `RunnableSolution` should continue to extend legacy `Solution`

### DIFF
--- a/legacy/ignition/Contracts/RunnableSolution.php
+++ b/legacy/ignition/Contracts/RunnableSolution.php
@@ -2,6 +2,15 @@
 
 namespace Spatie\Ignition\Contracts;
 
-interface RunnableSolution extends \Spatie\ErrorSolutions\Contracts\RunnableSolution
+interface RunnableSolution extends Solution
 {
+    public function getSolutionActionDescription(): string;
+
+    public function getRunButtonText(): string;
+
+    /** @param array<string, mixed> $parameters */
+    public function run(array $parameters = []): void;
+
+    /** @return array<string, mixed> */
+    public function getRunParameters(): array;
 }


### PR DESCRIPTION
This pull request fixes #5, where the *legacy* `RunnableSolution` interface was no longer implementing the *legacy* `Solution` interface, which was causing return type errors.

I've provided some more information on the issue, along with an example repository which can be used to reproduce the issue: https://github.com/duncanmcclean/spatie-ignition-runnable-solutions-return-type-error

This PR attempts to fix the issue by continuing to extend the legacy `Solution` interface, which meant having to re-add the runnable solution methods to the interface.