### PR TITLE
Allow to customize OpenAI Model

### DIFF
--- a/src/SolutionProviders/Laravel/OpenAiSolutionProvider.php
+++ b/src/SolutionProviders/Laravel/OpenAiSolutionProvider.php
@@ -31,7 +31,7 @@ class OpenAiSolutionProvider implements HasSolutionsForThrowable
             cacheTtlInSeconds: 60,
             applicationType: 'Laravel ' . Str::before(app()->version(), '.'),
             applicationPath: base_path(),
-            openAiModel: config('error-solutions.open_ai_model','gpt-3.5-turbo'),
+            openAiModel: config('error-solutions.open_ai_model', 'gpt-3.5-turbo'),
         );
 
         return $solutionProvider->getSolutions($throwable);

--- a/src/SolutionProviders/Laravel/OpenAiSolutionProvider.php
+++ b/src/SolutionProviders/Laravel/OpenAiSolutionProvider.php
@@ -31,6 +31,7 @@ class OpenAiSolutionProvider implements HasSolutionsForThrowable
             cacheTtlInSeconds: 60,
             applicationType: 'Laravel ' . Str::before(app()->version(), '.'),
             applicationPath: base_path(),
+            openAiModel: config('error-solutions.open_ai_model','gpt-3.5-turbo'),
         );
 
         return $solutionProvider->getSolutions($throwable);

--- a/src/Solutions/OpenAi/OpenAiSolution.php
+++ b/src/Solutions/OpenAi/OpenAiSolution.php
@@ -99,9 +99,9 @@ class OpenAiSolution implements Solution
     }
 
     protected function getModel(): string
-     {
+    {
         return $this->openAiModel ?? 'gpt-3.5-turbo';
-     }
+    }
 
     protected function getApplicationFrame(Throwable $throwable): ?Frame
     {

--- a/src/Solutions/OpenAi/OpenAiSolution.php
+++ b/src/Solutions/OpenAi/OpenAiSolution.php
@@ -28,7 +28,7 @@ class OpenAiSolution implements Solution
         protected int|null            $cacheTtlInSeconds = 60,
         protected string|null         $applicationType = null,
         protected string|null         $applicationPath = null,
-        protected string              $openAiModel,
+        protected string|null         $openAiModel,
     ) {
         $this->prompt = $this->generatePrompt();
 
@@ -61,7 +61,7 @@ class OpenAiSolution implements Solution
         $solutionText = OpenAI::client($this->openAiKey)
             ->chat()
             ->create([
-                'model' => $this->openAiModel(),
+                'model' => $this->getModel(),
                 'messages' => [['role' => 'user', 'content' => $this->prompt]],
                 'max_tokens' => 1000,
                 'temperature' => 0,
@@ -97,6 +97,11 @@ class OpenAiSolution implements Solution
             $viewPath,
         );
     }
+
+    protected function getModel(): string
+     {
+        return $this->openAiModel ?? 'gpt-3.5-turbo';
+     }
 
     protected function getApplicationFrame(Throwable $throwable): ?Frame
     {

--- a/src/Solutions/OpenAi/OpenAiSolution.php
+++ b/src/Solutions/OpenAi/OpenAiSolution.php
@@ -28,6 +28,7 @@ class OpenAiSolution implements Solution
         protected int|null            $cacheTtlInSeconds = 60,
         protected string|null         $applicationType = null,
         protected string|null         $applicationPath = null,
+        protected string              $openAiModel,
     ) {
         $this->prompt = $this->generatePrompt();
 
@@ -60,7 +61,7 @@ class OpenAiSolution implements Solution
         $solutionText = OpenAI::client($this->openAiKey)
             ->chat()
             ->create([
-                'model' => $this->getModel(),
+                'model' => $this->openAiModel(),
                 'messages' => [['role' => 'user', 'content' => $this->prompt]],
                 'max_tokens' => 1000,
                 'temperature' => 0,
@@ -95,11 +96,6 @@ class OpenAiSolution implements Solution
             ['viewModel' => $viewModel],
             $viewPath,
         );
-    }
-
-    protected function getModel(): string
-    {
-        return 'gpt-3.5-turbo';
     }
 
     protected function getApplicationFrame(Throwable $throwable): ?Frame

--- a/src/Solutions/OpenAi/OpenAiSolution.php
+++ b/src/Solutions/OpenAi/OpenAiSolution.php
@@ -28,7 +28,7 @@ class OpenAiSolution implements Solution
         protected int|null            $cacheTtlInSeconds = 60,
         protected string|null         $applicationType = null,
         protected string|null         $applicationPath = null,
-        protected string|null         $openAiModel,
+        protected string|null         $openAiModel = null,
     ) {
         $this->prompt = $this->generatePrompt();
 

--- a/src/Solutions/OpenAi/OpenAiSolutionProvider.php
+++ b/src/Solutions/OpenAi/OpenAiSolutionProvider.php
@@ -14,6 +14,7 @@ class OpenAiSolutionProvider implements HasSolutionsForThrowable
         protected int $cacheTtlInSeconds = 60 * 60,
         protected string|null $applicationType = null,
         protected string|null $applicationPath = null,
+        protected string $openAiModel='gpt-3.5-turbo',
     ) {
         $this->cache ??= new DummyCache();
     }
@@ -33,6 +34,7 @@ class OpenAiSolutionProvider implements HasSolutionsForThrowable
                 $this->cacheTtlInSeconds,
                 $this->applicationType,
                 $this->applicationPath,
+                $this->openAiModel
             ),
         ];
     }

--- a/src/Solutions/OpenAi/OpenAiSolutionProvider.php
+++ b/src/Solutions/OpenAi/OpenAiSolutionProvider.php
@@ -9,12 +9,12 @@ use Throwable;
 class OpenAiSolutionProvider implements HasSolutionsForThrowable
 {
     public function __construct(
-        protected string $openAiKey,
-        protected ?CacheInterface $cache = null,
-        protected int $cacheTtlInSeconds = 60 * 60,
-        protected string|null $applicationType = null,
-        protected string|null $applicationPath = null,
-        protected string $openAiModel='gpt-3.5-turbo',
+        protected string            $openAiKey,
+        protected ?CacheInterface   $cache = null,
+        protected int               $cacheTtlInSeconds = 60 * 60,
+        protected string|null       $applicationType = null,
+        protected string|null       $applicationPath = null,
+        protected string            $openAiModel='gpt-3.5-turbo',
     ) {
         $this->cache ??= new DummyCache();
     }

--- a/src/Solutions/OpenAi/OpenAiSolutionProvider.php
+++ b/src/Solutions/OpenAi/OpenAiSolutionProvider.php
@@ -14,7 +14,7 @@ class OpenAiSolutionProvider implements HasSolutionsForThrowable
         protected int               $cacheTtlInSeconds = 60 * 60,
         protected string|null       $applicationType = null,
         protected string|null       $applicationPath = null,
-        protected string            $openAiModel='gpt-3.5-turbo',
+        protected string            $openAiModel = 'gpt-3.5-turbo',
     ) {
         $this->cache ??= new DummyCache();
     }


### PR DESCRIPTION
This PR allows to customize the OpenAI Model via the `config('error-solutions.open_ai_model')`
This allows the use of custom openai models like the new cheap `gpt-4o-mini`