### PR TITLE
Fix OpenAI response text links

### DIFF
--- a/src/Solutions/OpenAi/OpenAiSolutionResponse.php
+++ b/src/Solutions/OpenAi/OpenAiSolutionResponse.php
@@ -37,7 +37,9 @@ class OpenAiSolutionResponse
 
         $links = [];
         foreach ($textLinks as $textLink) {
-            $links[$textLink['title']] = $textLink['url'];
+            if (isset($textLink['title']) && isset($textLink['url'])) {
+                $links[$textLink['title']] = $textLink['url'];
+            }
         }
 
         return $links;


### PR DESCRIPTION
OpenAI API returns sometimes response without ENDLINKS word:

![image](https://github.com/user-attachments/assets/c2d7e3b9-5840-413c-99fb-d3686bcec35f)

It makes $textLinks variable contains this:

![image](https://github.com/user-attachments/assets/fc8fce7d-e629-4571-bd21-bb5847675bd3)

And then it throws this exception instead of Ignition page:

![image](https://github.com/user-attachments/assets/a9f5dfe9-d43e-4d80-9f40-943ffae22c43)

The problem occur with gpt-3.5-turbo model. With model gpt-4* looks OK. But responses are changing, so it can happen with gpt-4* too.

This PR fixes the problem quickly.