### PR TITLE
Replace implicitly nullable parameters for PHP 8.4

### DIFF
--- a/src/Solutions/Laravel/MakeViewVariableOptionalSolution.php
+++ b/src/Solutions/Laravel/MakeViewVariableOptionalSolution.php
@@ -15,7 +15,7 @@ class MakeViewVariableOptionalSolution implements RunnableSolution
 
     protected ?string $viewFile;
 
-    public function __construct(string $variableName = null, string $viewFile = null)
+    public function __construct(?string $variableName = null, ?string $viewFile = null)
     {
         $this->variableName = $variableName;
 

--- a/src/Solutions/SuggestCorrectVariableNameSolution.php
+++ b/src/Solutions/SuggestCorrectVariableNameSolution.php
@@ -15,7 +15,7 @@ class SuggestCorrectVariableNameSolution implements Solution
 
     protected ?string $suggested;
 
-    public function __construct(string $variableName = null, string $viewFile = null, string $suggested = null)
+    public function __construct(?string $variableName = null, ?string $viewFile = null, ?string $suggested = null)
     {
         $this->variableName = $variableName;
 


### PR DESCRIPTION
This PR removes implicitly nullable parameters because of deprecation warnings for PHP 8.4.

https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter
