### PR TITLE
Remove unneccesary conditional in "Run Tests" workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,7 +51,6 @@ jobs:
            composer update --with="livewire/livewire:^${{ matrix.livewire }}" --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
 
       -   name: Install extra package
-          if: matrix.php != '8.0'
           run: composer require openai-php/client
 
       - name: Execute tests


### PR DESCRIPTION
This package only supports PHP ^8.1, so this conditional is no longer needed.