### PR TITLE
Supports Laravel 12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,13 +10,15 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [10.*, 11.*]
+        laravel: [10.*, 11.*, 12.*]
         livewire: [2.11, 3.3.5]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest, windows-latest]
         exclude:
           - php: 8.1
             laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
           - laravel: 11.*
             livewire: 2.11
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         php: [8.1, 8.2, 8.3]
         laravel: [10.*, 11.*, 12.*]
-        livewire: [2.11, 3.3.5]
+        livewire: [2.11, 3.5.20]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest, windows-latest]
         exclude:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,8 @@ jobs:
             laravel: 12.*
           - laravel: 11.*
             livewire: 2.11
+          - laravel: 12.*
+            livewire: 2.11
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - LW${{ matrix.livewire }} -${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/cache" : "^5.4|^6.0|^7.0",
         "symfony/process" : "^5.4|^6.0|^7.0",
         "vlucas/phpdotenv" : "^5.5",
-        "orchestra/testbench": "^7.0|8.22.3|^9.0|^10.0"
+        "orchestra/testbench": "8.22.3|^9.0|^10.0"
     },
     "autoload" : {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^8.0"
     },
     "require-dev" : {
-        "livewire/livewire": "^2.11|^3.3.5",
+        "livewire/livewire": "^2.11|^3.5.20",
         "illuminate/support": "^10.0|^11.0|^12.0",
         "illuminate/broadcasting" : "^10.0|^11.0|^12.0",
         "openai-php/client": "^0.10.1",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/broadcasting" : "^10.0|^11.0|^12.0",
         "openai-php/client": "^0.10.1",
         "illuminate/cache" : "^10.0|^11.0|^12.0",
-        "pestphp/pest" : "^2.20",
+        "pestphp/pest" : "^3.0",
         "phpstan/phpstan" : "^2.1",
         "psr/simple-cache-implementation" : "^3.0",
         "psr/simple-cache" : "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/support": "^10.0|^11.0|^12.0",
         "illuminate/broadcasting" : "^10.0|^11.0|^12.0",
         "openai-php/client": "^0.10.1",
-        "illuminate/cache" : "^10.0|^11.0",
+        "illuminate/cache" : "^10.0|^11.0|^12.0",
         "pestphp/pest" : "^2.20",
         "phpstan/phpstan" : "^2.1",
         "psr/simple-cache-implementation" : "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     },
     "require-dev" : {
         "livewire/livewire": "^2.11|^3.3.5",
-        "illuminate/support": "^10.0|^11.0",
-        "illuminate/broadcasting" : "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/broadcasting" : "^10.0|^11.0|^12.0",
         "openai-php/client": "^0.10.1",
         "illuminate/cache" : "^10.0|^11.0",
         "pestphp/pest" : "^2.20",
@@ -31,7 +31,7 @@
         "symfony/cache" : "^5.4|^6.0|^7.0",
         "symfony/process" : "^5.4|^6.0|^7.0",
         "vlucas/phpdotenv" : "^5.5",
-        "orchestra/testbench": "^7.0|8.22.3|^9.0"
+        "orchestra/testbench": "^7.0|8.22.3|^9.0|^10.0"
     },
     "autoload" : {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/broadcasting" : "^10.0|^11.0|^12.0",
         "openai-php/client": "^0.10.1",
         "illuminate/cache" : "^10.0|^11.0|^12.0",
-        "pestphp/pest" : "^3.0",
+        "pestphp/pest" : "^2.20|^3.0",
         "phpstan/phpstan" : "^2.1",
         "psr/simple-cache-implementation" : "^3.0",
         "psr/simple-cache" : "^3.0",


### PR DESCRIPTION
This pull request adds Laravel 12 support to `spatie/error-solutions`.

Depends on:

* [x] https://github.com/livewire/livewire/pull/9155