### PR TITLE
Add support for bun.lock and bun.lockb files to v1

### DIFF
--- a/src/SolutionProviders/Laravel/MissingViteManifestSolutionProvider.php
+++ b/src/SolutionProviders/Laravel/MissingViteManifestSolutionProvider.php
@@ -37,6 +37,8 @@ class MissingViteManifestSolutionProvider implements HasSolutionsForThrowable
     {
         /** @var string */
         $baseCommand = collect([
+            'bun.lockb' => 'bun',
+            'bun.lock' => 'bun',
             'pnpm-lock.yaml' => 'pnpm',
             'yarn.lock' => 'yarn',
         ])->first(fn ($_, $lockfile) => file_exists(base_path($lockfile)), 'npm run');


### PR DESCRIPTION
Can we add this change to v1 as well and patch release this? I have a bit of an older project this comes up on where it shows to use npm when our team uses Bun. Could be useful for anyone who runs into this.

Same change as...
[](https://github.com/spatie/error-solutions/pull/39)